### PR TITLE
Features: Adds tracking of Governors at Issuer level.

### DIFF
--- a/contracts/fast/FastAccessFacet.sol
+++ b/contracts/fast/FastAccessFacet.sol
@@ -6,6 +6,7 @@ import '../interfaces/IHasGovernors.sol';
 import '../lib/LibAddressSet.sol';
 import '../lib/LibPaginate.sol';
 import '../marketplace/MarketplaceAccessFacet.sol';
+import '../issuer/IssuerAccessFacet.sol';
 import './FastTokenFacet.sol';
 import './lib/AFastFacet.sol';
 import './lib/LibFast.sol';
@@ -71,6 +72,8 @@ contract FastAccessFacet is AFastFacet, IHasMembers, IHasGovernors {
       onlyMarketplaceMember(governor) {
     // Add governor to list.
     LibFastAccess.data().governorSet.add(governor, false);
+    // Notify issuer that this member was added to this FAST.
+    IssuerAccessFacet(LibFast.data().issuer).governorAddedToFast(governor);
     // Emit!
     FastFrontendFacet(address(this)).emitDetailsChanged();
     emit GovernorAdded(governor);
@@ -84,6 +87,8 @@ contract FastAccessFacet is AFastFacet, IHasMembers, IHasGovernors {
       onlyIssuerMember {
     // Remove governor.
     LibFastAccess.data().governorSet.remove(governor, false);
+    // Notify issuer that this member was removed from this FAST.
+    IssuerAccessFacet(LibFast.data().issuer).governorRemovedFromFast(governor);
     // Emit!
     FastFrontendFacet(address(this)).emitDetailsChanged();
     emit GovernorRemoved(governor);

--- a/contracts/issuer/IssuerAccessFacet.sol
+++ b/contracts/issuer/IssuerAccessFacet.sol
@@ -85,8 +85,7 @@ contract IssuerAccessFacet is AIssuerFacet, IHasMembers {
       LibConstants.REQUIRES_FAST_CONTRACT_CALLER
     );
     // Keep track of the governorship.
-    LibAddressSet.Data storage governorships = LibIssuerAccess.data().fastGovernorships[governor];
-    governorships.add(msg.sender, false);
+    LibIssuerAccess.data().fastGovernorships[governor].add(msg.sender, false);
   }
 
   /** @notice Callback from FAST contracts allowing the Issuer contract to keep track of governorships.
@@ -100,8 +99,7 @@ contract IssuerAccessFacet is AIssuerFacet, IHasMembers {
       LibConstants.REQUIRES_FAST_CONTRACT_CALLER
     );
     // Remove the tracked governorship.
-    LibAddressSet.Data storage governorships = LibIssuerAccess.data().fastGovernorships[governor];
-    governorships.remove(msg.sender, false);
+    LibIssuerAccess.data().fastGovernorships[governor].remove(msg.sender, false);
   }
 
   /** @notice Returns a list of FASTs that the passed address is a governor of.

--- a/contracts/issuer/IssuerAccessFacet.sol
+++ b/contracts/issuer/IssuerAccessFacet.sol
@@ -105,13 +105,15 @@ contract IssuerAccessFacet is AIssuerFacet, IHasMembers {
   }
 
   /** @notice Returns a list of FASTs that the passed address is a governor of.
-   * @param governor The governor to return a list of FASTs for.
-   * @return address[] A list of FAST addresses.
+   * @param governor is the address to check governorships of.
+   * @param cursor is the index at which to start.
+   * @param perPage is how many records should be returned at most.
+   * @return A `address[]` list of values at most `perPage` big.
+   * @return A `uint256` index to the next page.
    */
-  function governorshipsFor(address governor)
+  function paginateGovernorships(address governor, uint256 cursor, uint256 perPage)
       external view
-      returns (address[] memory) {
-    LibAddressSet.Data storage governorships = LibIssuerAccess.data().fastGovernorships[governor];
-    return governorships.values;
+      returns(address[] memory, uint256) {
+    return LibPaginate.addresses(LibIssuerAccess.data().fastGovernorships[governor].values, cursor, perPage);
   }
 }

--- a/contracts/issuer/lib/LibIssuerAccess.sol
+++ b/contracts/issuer/lib/LibIssuerAccess.sol
@@ -15,6 +15,8 @@ library LibIssuerAccess {
     uint16 version;
     // This is where we hold our members data.
     LibAddressSet.Data memberSet;
+    // For a given address we store list of FASTs where that address is a governor.
+    mapping(address => LibAddressSet.Data) fastGovernorships;
   }
 
   function data()

--- a/test/issuer/IssuerAccessFacet.test.ts
+++ b/test/issuer/IssuerAccessFacet.test.ts
@@ -171,7 +171,7 @@ describe('IssuerAccessFacet', () => {
       issuerAsFast.governorAddedToFast(alice.address);
 
       // Expecting the FAST address to be included in FASTs Alice is a governor of.
-      const subject = await access.governorshipsFor(alice.address);
+      const [subject, /* nextCursor */] = await access.paginateGovernorships(alice.address, 0, 10);
       expect(subject).to.be.eql([
         fast.address
       ]);
@@ -197,12 +197,12 @@ describe('IssuerAccessFacet', () => {
       issuerAsFast.governorRemovedFromFast(alice.address);
 
       // Expecting the FAST address to not be included in FASTs Alice is a governor of.
-      const subject = await access.governorshipsFor(alice.address);
+      const [subject, /* nextCursor */] = await access.paginateGovernorships(alice.address, 0, 10);
       expect(subject).to.be.empty;
     });
   });
 
-  describe('governorshipsFor', async () => {
+  describe('paginateGovernorships', async () => {
     beforeEach(async () => {
       // This FAST is registered.
       await issuerMemberIssuer.registerFast(fast.address);
@@ -213,11 +213,10 @@ describe('IssuerAccessFacet', () => {
     });
 
     it('given an address, returns the list of FASTs that it is a governor of', async () => {
-      const subject = await access.governorshipsFor(alice.address);
+      const [subject, /* nextCursor */] = await access.paginateGovernorships(alice.address, 0, 10)
       expect(subject).to.be.eql([
         fast.address
       ]);
     });
   });
-
 });


### PR DESCRIPTION
This PR:

- Adds tracking of Governors at the Issuer level aka: Given an `address` return a paginated list of FAST addresses for which that `address` is a Governor.
- Adds `paginateGovernorships(address, cursor, perPage)` to `IssuerAccessFacet` to query which FASTs an `address` is a governor of (if any).

---

### Notes

- This is currently on the `Issuer`... it _could_ be moved to the `Marketplace`.
- 💥 As @afmfe-iul rightly pointed out... this adds the functionality but the actual list isn't going to be populated with current governors. This kind of touches on migration of data topic too. We either start from scratch again or need to handle adding existing FAST governors.